### PR TITLE
Add trunk of distributed library

### DIFF
--- a/files/initialize-codebase.sh
+++ b/files/initialize-codebase.sh
@@ -32,4 +32,5 @@ echo "pull https://github.com/thoradam/unison-read:.releases._v0 contrib.thorada
 #
 # Next, v2 codebases. Put your codebase here if you have already moved to the new v2 codebase format
 #
-echo "pull https://github.com/unisonweb/base_v2:.trunk .base" | /usr/local/bin/ucm
+echo "pull https://github.com/unisonweb/base:.trunk .base" | /usr/local/bin/ucm
+echo "pull https://github.com/unisonweb/distributed:.trunk .distributed" | /usr/local/bin/ucm


### PR DESCRIPTION
And update base url to not have `_v2` on the end, though I think that still works due to a redirect