### PR TITLE
Update initialize-codebase.sh - pull 'cell' type into contrib on unison share

### DIFF
--- a/files/initialize-codebase.sh
+++ b/files/initialize-codebase.sh
@@ -35,4 +35,5 @@ echo "pull https://github.com/thoradam/unison-read:.releases._v0 contrib.thorada
 echo "pull https://github.com/unisonweb/base:.trunk .base" | /usr/local/bin/ucm
 echo "pull https://github.com/unisonweb/distributed:.trunk .distributed" | /usr/local/bin/ucm
 echo "pull https://github.com/unisonweb/http:.http.trunk .http" | /usr/local/bin/ucm
+echo "pull https://github.com/atacratic/unison-playpen.git:.cell.trunk .contrib.atacratic.cell" | /usr/local/bin/ucm
 echo "pull https://github.com/stew/unison-remote:.trunk .contrib.stew.remote" | /usr/local/bin/ucm


### PR DESCRIPTION
Pull in some code into contrib, a 'cell' type.  An example of using Channels.  

The included documentation starts as follows.

```
  The `Cell` type provides mutable state for access between tasks.
  
  This is a simple variable with no timestamping, versioning, or merging. Any concurrent accesses
  will race and result in non-deterministic behavior.
  
  All the `Cell` operations require the Channels ability: internally, read/update requests are send
  to the cell via channels, and (short-lived) channels are used to carry the responses. In addition
  `Cell.new` requires the Fork ability, in order to fork a task that handles incoming read/update
  requests for the cell.
```